### PR TITLE
[feat] 최초 실행시 술드컵 실행 시나리오 추가

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -37,15 +37,21 @@
             android:exported="true">
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />
+
                 <category android:name="android.intent.category.DEFAULT" />
                 <category android:name="android.intent.category.BROWSABLE" />
+
                 <data
                     android:host="oauth"
                     android:scheme="kakaofae8c16c354a469723b8e15018fb46d9" />
             </intent-filter>
         </activity>
+        <activity
+            android:name=".ui.worldcup.WorldcupActivity"
+            android:theme="@style/Theme.AppCompat.NoActionBar"
+            android:exported="true">
+        </activity>
         <activity android:name=".MainActivity" />
-        <activity android:name=".ui.worldcup.WorldcupActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/java/com/mashup/zuzu/MainActivity.kt
+++ b/app/src/main/java/com/mashup/zuzu/MainActivity.kt
@@ -1,5 +1,6 @@
 package com.mashup.zuzu
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
@@ -10,6 +11,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import com.google.accompanist.systemuicontroller.rememberSystemUiController
 import com.mashup.zuzu.compose.theme.ProofTheme
+import com.mashup.zuzu.ui.login.LoginActivity
+import com.mashup.zuzu.ui.worldcup.WorldcupActivity
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint
@@ -29,7 +32,9 @@ class MainActivity : ComponentActivity() {
                     modifier = Modifier.fillMaxSize()
                 ) {
                     ZuzuApp(
-                        onWorldCupButtonClick = {}
+                        onWorldCupButtonClick = {
+                            startActivity(Intent(this, WorldcupActivity::class.java))
+                        }
                     )
                 }
             }

--- a/app/src/main/java/com/mashup/zuzu/ui/login/LoginActivity.kt
+++ b/app/src/main/java/com/mashup/zuzu/ui/login/LoginActivity.kt
@@ -13,6 +13,9 @@ import com.kakao.sdk.user.UserApiClient
 import com.mashup.zuzu.MainActivity
 import com.mashup.zuzu.R
 import com.mashup.zuzu.databinding.ActivityLoginBinding
+import com.mashup.zuzu.ui.worldcup.WorldcupActivity
+import com.mashup.zuzu.util.Constants
+import com.mashup.zuzu.util.Key
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.launch
 import timber.log.Timber
@@ -35,15 +38,34 @@ class LoginActivity : AppCompatActivity() {
                 viewModel.actionFlow.collect { action ->
                     when (action) {
                         LoginViewModel.Action.ClickKakaoLogin -> getKakaoAccessToken()
-                        LoginViewModel.Action.ClickSkip -> startMainActivity()
-                        LoginViewModel.Action.ProofAuthSuccess -> startMainActivity()
                         LoginViewModel.Action.ProofAuthFailed ->
-                            Toast.makeText(this@LoginActivity, "로그인에 실패했습니다.", Toast.LENGTH_SHORT)
-                                .show()
+                            Toast.makeText(
+                                this@LoginActivity,
+                                "로그인에 실패했습니다.",
+                                Toast.LENGTH_SHORT
+                            ).show()
+                        LoginViewModel.Action.StartMain -> startProof(Constants.MAIN_ACTIVITY)
+                        LoginViewModel.Action.StartWorldcup -> startProof(Constants.WORLDCUP_ACTIVITY)
                     }
                 }
             }
         }
+    }
+
+    private fun startProof(targetActivity: String?) {
+        val intent: Intent
+        when (targetActivity) {
+            Constants.MAIN_ACTIVITY -> {
+                intent = Intent(this@LoginActivity, MainActivity::class.java)
+            }
+            else -> {
+                intent = Intent(this@LoginActivity, WorldcupActivity::class.java)
+                intent.putExtra(Key.NEXT_ACTIVITY, Constants.MAIN_ACTIVITY)
+            }
+        }
+        startActivity(intent)
+        overridePendingTransition(0, 0)
+        finish()
     }
 
     private fun getKakaoAccessToken() {
@@ -55,12 +77,5 @@ class LoginActivity : AppCompatActivity() {
                 viewModel.getProofAuthData(token.accessToken)
             }
         }
-    }
-
-    private fun startMainActivity() {
-        val intent = Intent(this, MainActivity::class.java)
-        startActivity(intent)
-        overridePendingTransition(0, 0);
-        finish()
     }
 }

--- a/app/src/main/java/com/mashup/zuzu/ui/login/LoginViewModel.kt
+++ b/app/src/main/java/com/mashup/zuzu/ui/login/LoginViewModel.kt
@@ -21,8 +21,8 @@ class LoginViewModel @Inject constructor(
 
     sealed class Action {
         object ClickKakaoLogin : Action()
-        object ClickSkip : Action()
-        object ProofAuthSuccess : Action()
+        object StartMain : Action()
+        object StartWorldcup : Action()
         object ProofAuthFailed : Action()
     }
 
@@ -39,7 +39,7 @@ class LoginViewModel @Inject constructor(
                             commit(Key.Preference.ACCESS_TOKEN, result.value.accessToken)
                             commit(Key.Preference.REFRESH_TOKEN, result.value.refreshToken)
                         }
-                        channel.trySend(Action.ProofAuthSuccess)
+                        startActivity()
                     }
                     is Results.Failure -> {
                         channel.trySend(Action.ProofAuthFailed)
@@ -55,6 +55,16 @@ class LoginViewModel @Inject constructor(
     }
 
     fun onClickSkip() {
-        channel.trySend(Action.ClickSkip)
+        startActivity()
+    }
+
+    private fun startActivity() {
+        val isFirstRun = proofPreference.get(Key.Preference.IS_FIRST_RUN, true)
+        if (!isFirstRun) {
+            channel.trySend(Action.StartMain)
+        } else {
+            channel.trySend(Action.StartWorldcup)
+            proofPreference.commit(Key.Preference.IS_FIRST_RUN, false)
+        }
     }
 }

--- a/app/src/main/java/com/mashup/zuzu/ui/worldcup/WorldcupActivity.kt
+++ b/app/src/main/java/com/mashup/zuzu/ui/worldcup/WorldcupActivity.kt
@@ -1,39 +1,77 @@
 package com.mashup.zuzu.ui.worldcup
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.databinding.DataBindingUtil
-import com.mashup.zuzu.BuildConfig
-import com.mashup.zuzu.ProofPreferenceImpl
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.lifecycleScope
+import androidx.lifecycle.repeatOnLifecycle
+import com.mashup.zuzu.MainActivity
 import com.mashup.zuzu.R
 import com.mashup.zuzu.bridge.ProofPreference
+import com.mashup.zuzu.bridge.WebAPIController
 import com.mashup.zuzu.databinding.ActivityWorldcupBinding
+import com.mashup.zuzu.util.Constants
+import com.mashup.zuzu.util.Key
+import com.mashup.zuzu.util.WebConstants
+import dagger.hilt.android.AndroidEntryPoint
+import kotlinx.coroutines.launch
+import javax.inject.Inject
 
+@AndroidEntryPoint
 class WorldcupActivity : AppCompatActivity() {
 
-    lateinit var binding: ActivityWorldcupBinding
+    private lateinit var binding: ActivityWorldcupBinding
 
+    @Inject
     lateinit var proofPreference: ProofPreference
+
+    private var nextActivity = ""
 
     private val viewModel by viewModels<WorldcupViewModel>()
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
-
-        binding = DataBindingUtil.setContentView(this, R.layout.activity_worldcup)
-        binding.lifecycleOwner = this
-
-        proofPreference = ProofPreferenceImpl(this, BuildConfig.APPLICATION_ID)
-
+        if (!intent.getStringExtra(Key.NEXT_ACTIVITY).isNullOrEmpty()) {
+            nextActivity = intent.getStringExtra(Key.NEXT_ACTIVITY).toString()
+        }
         initViews()
+        observeWebRequest()
     }
 
     private fun initViews() {
+        binding = DataBindingUtil.setContentView(this, R.layout.activity_worldcup)
+        binding.lifecycleOwner = this
         binding.viewModel = viewModel
         with(binding) {
             worldcupWebView.setJavaScriptInterface(proofPreference)
-            worldcupWebView.loadUrl("http://192.168.0.10:3000")
+            worldcupWebView.loadUrl(WebConstants.URL.WORLDCUP)
+        }
+    }
+
+    private fun observeWebRequest() {
+        lifecycleScope.launch {
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
+                WebAPIController.channelFlow.collect { jsonObject ->
+                    when (jsonObject.get(WebConstants.FUNCTION_NAME).asString) {
+                        WebAPIController.FunctionName.CLOSE_WEB_VIEW -> finish()
+                    }
+                }
+            }
+        }
+    }
+
+    override fun onBackPressed() {
+        if (binding.worldcupWebView.canGoBack()) {
+            binding.worldcupWebView.goBack()
+        } else {
+            if (nextActivity == Constants.MAIN_ACTIVITY) {
+                val intent = Intent(this@WorldcupActivity, MainActivity::class.java)
+                startActivity(intent)
+            }
+            finish()
         }
     }
 }

--- a/app/src/main/java/com/mashup/zuzu/ui/worldcup/WorldcupViewModel.kt
+++ b/app/src/main/java/com/mashup/zuzu/ui/worldcup/WorldcupViewModel.kt
@@ -1,6 +1,9 @@
 package com.mashup.zuzu.ui.worldcup
 
 import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
 
-class WorldcupViewModel : ViewModel() {
+@HiltViewModel
+class WorldcupViewModel @Inject constructor(): ViewModel() {
 }

--- a/app/src/main/java/com/mashup/zuzu/util/Constants.kt
+++ b/app/src/main/java/com/mashup/zuzu/util/Constants.kt
@@ -1,0 +1,6 @@
+package com.mashup.zuzu.util
+
+object Constants {
+    const val MAIN_ACTIVITY = "MainActivity"
+    const val WORLDCUP_ACTIVITY = "WorldcupActivity"
+}

--- a/app/src/main/java/com/mashup/zuzu/util/Key.kt
+++ b/app/src/main/java/com/mashup/zuzu/util/Key.kt
@@ -1,8 +1,11 @@
 package com.mashup.zuzu.util
 
 object Key {
+    const val NEXT_ACTIVITY = "nextActivity"
+
     object Preference {
         const val ACCESS_TOKEN = "accessToken"
         const val REFRESH_TOKEN = "refreshToken"
+        const val IS_FIRST_RUN = "isFirstRun"
     }
 }

--- a/app/src/main/java/com/mashup/zuzu/util/WebConstants.kt
+++ b/app/src/main/java/com/mashup/zuzu/util/WebConstants.kt
@@ -1,0 +1,9 @@
+package com.mashup.zuzu.util
+
+object WebConstants {
+    const val FUNCTION_NAME = "functionName"
+
+    object URL {
+        const val WORLDCUP = "https://zuzu-web.vercel.app"
+    }
+}


### PR DESCRIPTION
## 변경 사항
- 최초 실행시 술드컵 웹뷰를 실행합니다.
- 최초 실행이 아닐 경우 술드컵 아닌 스플래시 -> MainActivity 순서로 진입합니다.
- 단, 미로그인 상태의 경우 스플래시 -> LoginActivity -> MainActivity로 진입합니다.
- LoginActivity -> 술드컵 -> 종료될 때 마지막 Activity가 'MainActivity'가 되는 시나리오 반영을 위해 술드컵 실행시 "nextActivity" 데이터를 intent로 수신하여 이후 로직을 분기하였습니다.
- MainActivity의 FAB 버튼 클릭시 술드컵 웹뷰를 실행합니다.